### PR TITLE
two minor fixes in comments of generated files

### DIFF
--- a/macros/acb_macros.pxd
+++ b/macros/acb_macros.pxd
@@ -1,5 +1,5 @@
 # Macros from acb.h
-# See https://github.com/flintlib/flint/issues/152
+# See https://github.com/flintlib/flint/issues/1529
 
 from .types cimport *
 

--- a/macros/acb_mat_macros.pxd
+++ b/macros/acb_mat_macros.pxd
@@ -1,5 +1,5 @@
 # Macros from acb_mat.h
-# See https://github.com/flintlib/flint/issues/152
+# See https://github.com/flintlib/flint/issues/1529
 
 from .types cimport *
 

--- a/macros/acb_poly_macros.pxd
+++ b/macros/acb_poly_macros.pxd
@@ -1,5 +1,5 @@
 # Macros from acb_poly.h
-# See https://github.com/flintlib/flint/issues/152
+# See https://github.com/flintlib/flint/issues/1529
 
 from .types cimport *
 

--- a/macros/arb_macros.pxd
+++ b/macros/arb_macros.pxd
@@ -1,5 +1,5 @@
 # Macros from arb.h
-# See https://github.com/flintlib/flint/issues/152
+# See https://github.com/flintlib/flint/issues/1529
 
 from .types cimport *
 

--- a/macros/arb_mat_macros.pxd
+++ b/macros/arb_mat_macros.pxd
@@ -1,5 +1,5 @@
 # Macros from arb_mat.h
-# See https://github.com/flintlib/flint/issues/152
+# See https://github.com/flintlib/flint/issues/1529
 
 from .types cimport *
 

--- a/macros/fmpq_mat_macros.pxd
+++ b/macros/fmpq_mat_macros.pxd
@@ -1,5 +1,5 @@
 # Macros from fmpq_mat.h
-# See https://github.com/flintlib/flint/issues/152
+# See https://github.com/flintlib/flint/issues/1529
 
 from .types cimport *
 

--- a/macros/fmpz_mat_macros.pxd
+++ b/macros/fmpz_mat_macros.pxd
@@ -1,5 +1,5 @@
 # Macros from fmpz_mat.h
-# See https://github.com/flintlib/flint/issues/152
+# See https://github.com/flintlib/flint/issues/1529
 
 from .types cimport *
 

--- a/macros/fmpz_poly_macros.pxd
+++ b/macros/fmpz_poly_macros.pxd
@@ -1,5 +1,5 @@
 # Macros from fmpz_poly.h
-# See https://github.com/flintlib/flint/issues/152
+# See https://github.com/flintlib/flint/issues/1529
 
 from .types cimport *
 

--- a/macros/mag_macros.pxd
+++ b/macros/mag_macros.pxd
@@ -1,5 +1,5 @@
 # Macros from mag.h
-# See https://github.com/flintlib/flint/issues/152
+# See https://github.com/flintlib/flint/issues/1529
 
 from .types cimport *
 

--- a/types.pxd.template
+++ b/types.pxd.template
@@ -1706,7 +1706,7 @@ cdef extern from "flint_wrap.h":
     ctypedef void ((*gr_method_init_clear_op)(gr_ptr, gr_ctx_ptr))
     ctypedef void ((*gr_method_swap_op)(gr_ptr, gr_ptr, gr_ctx_ptr))
     ctypedef int ((*gr_method_ctx)(gr_ctx_ptr))
-    # NOTE: we removed an extra paranthesis so that Cython is less confused
+    # NOTE: we removed an extra parenthesis so that Cython is less confused
     # see https://github.com/cython/cython/issues/5779
     ctypedef truth_t (*gr_method_ctx_predicate)(gr_ctx_ptr)
     ctypedef int ((*gr_method_ctx_set_si)(gr_ctx_ptr, slong))
@@ -1767,7 +1767,7 @@ cdef extern from "flint_wrap.h":
     ctypedef int ((*gr_method_quaternary_binary_op)(gr_ptr, gr_ptr, gr_ptr, gr_ptr, gr_srcptr, gr_srcptr, gr_ctx_ptr))
     ctypedef int ((*gr_method_quaternary_ternary_op)(gr_ptr, gr_ptr, gr_ptr, gr_ptr, gr_srcptr, gr_srcptr, gr_srcptr, gr_ctx_ptr))
     ctypedef int ((*gr_method_si_si_quaternary_op)(gr_ptr, slong, slong, gr_srcptr, gr_srcptr, gr_ctx_ptr))
-    # NOTE: we removed an extra paranthesis so that Cython is less confused
+    # NOTE: we removed an extra parenthesis so that Cython is less confused
     # see https://github.com/cython/cython/issues/5779
     ctypedef truth_t (*gr_method_unary_predicate)(gr_srcptr, gr_ctx_ptr)
     ctypedef truth_t (*gr_method_binary_predicate)(gr_srcptr, gr_srcptr, gr_ctx_ptr)
@@ -1786,7 +1786,7 @@ cdef extern from "flint_wrap.h":
     ctypedef int ((*gr_method_vec_scalar_op_ui)(gr_ptr, gr_srcptr, slong, ulong, gr_ctx_ptr))
     ctypedef int ((*gr_method_vec_scalar_op_fmpz)(gr_ptr, gr_srcptr, slong, const fmpz_t, gr_ctx_ptr))
     ctypedef int ((*gr_method_vec_scalar_op_fmpq)(gr_ptr, gr_srcptr, slong, const fmpq_t, gr_ctx_ptr))
-    # NOTE: we removed an extra paranthesis so that Cython is less confused
+    # NOTE: we removed an extra parenthesis so that Cython is less confused
     # see https://github.com/cython/cython/issues/5779
     ctypedef truth_t (*gr_method_vec_predicate)(gr_srcptr, slong, gr_ctx_ptr)
     ctypedef truth_t (*gr_method_vec_vec_predicate)(gr_srcptr, gr_srcptr, slong, gr_ctx_ptr)


### PR DESCRIPTION
- fix ref to flint issue about documentation of macros
- fix typo
